### PR TITLE
feat link to item on merchant_items_path, creates merchant_item_path

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -2,4 +2,9 @@ class MerchantItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
   end
+
+  def show
+    @merchant = Merchant.find(params[:merchant_id])
+    @merchant_items = @merchant.items
+  end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,9 +1,15 @@
 <h1><%= @merchant.name %> Items</h1>
 
 <ol>
+  <div class="merchant_items" >
   <% @merchant.items.each do |item| %>
     <li>
     <h3>Item name: <%= item.name %></h3>
+      <%= link_to item.name,  merchant_item_path(@merchant, item) %>
     </li>
   <%end%>
+  </div>
 </ol>
+
+
+

--- a/app/views/merchant_items/show.html.erb
+++ b/app/views/merchant_items/show.html.erb
@@ -1,0 +1,11 @@
+<h1> <%= @merchant.name %> Items </h1>
+
+<ol></ol>
+<% @merchant_items.each do |item| %>
+  <h3><%= item.name %></h3>
+  <li>
+    Description: <%= item.description %>
+    Price: <%= item.unit_price %>
+    </li>
+<% end %>
+</ol>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Merchant Items Index' do
     @mug = create(:item, name: "mug", merchant: @merchant1)
     @ember = create(:item, name: "ember", merchant: @merchant2)
     @plant = create(:item, name: "plant", merchant: @merchant2)
+
     visit merchant_items_path(@merchant1)
   end
 
@@ -26,6 +27,22 @@ RSpec.describe 'Merchant Items Index' do
       # And I do not see items for any other merchant
       expect(page).to_not have_content(@ember.name)
       expect(page).to_not have_content(@plant.name)
+    end
+
+    describe "User story 7a" do
+      it 'has a link for each item' do
+        within ".merchant_items" do
+          expect(page).to have_link("#{@table.name}", href: merchant_item_path(@merchant1, @table))
+          expect(page).to have_link("#{@pen.name}", href: merchant_item_path(@merchant1, @pen))
+          expect(page).to have_link("#{@mat.name}", href: merchant_item_path(@merchant1, @mat))
+          expect(page).to have_link("#{@mug.name}", href: merchant_item_path(@merchant1, @mug))
+          expect(page).not_to have_link("#{@ember.name}", href: merchant_item_path(@merchant1, @ember))
+        end
+
+        click_link @table.name
+        expect(current_path).to eq(merchant_item_path(@merchant1, @table))
+        visit merchant_items_path(@merchant2)
+      end
     end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe 'Merchant Items Index' do
 
         click_link @table.name
         expect(current_path).to eq(merchant_item_path(@merchant1, @table))
-        visit merchant_items_path(@merchant2)
       end
     end
   end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items Index' do
+  before :each do
+    @merchant1 = create(:merchant)
+    @merchant2 = create(:merchant)
+
+    @table = create(:item, name: "table", merchant: @merchant1)
+    @pen = create(:item, name: "pen", merchant: @merchant2)
+
+
+    visit merchant_item_path(@merchant1, @table)
+  end
+
+  describe 'User story 7b' do
+    it 'displays item attributes' do
+      # And I see all of the item's attributes including:
+        expect(page).to have_content(@table.name)
+        expect(page).to have_content(@table.description)
+        expect(page).to have_content(@table.unit_price)
+        expect(page).to_not have_content(@pen.name)
+    end
+  end
+end


### PR DESCRIPTION
This user story was split up into two parts, the first being on the merchant_item index page
- this adds a link to each item that takes user to item show page

The second part is the merchant_item_path.  
- This displays the items attributes